### PR TITLE
Update dependencies and OTLP exporter to reflect upstream 1.0.0beta changes

### DIFF
--- a/SampleApp/composer.json
+++ b/SampleApp/composer.json
@@ -1,7 +1,7 @@
 {
     "type": "project",
     "license": "proprietary",
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
         "ext-ctype": "*",
@@ -9,10 +9,11 @@
         "aws/aws-sdk-php": "^3.234",
         "aws/aws-sdk-php-symfony": "^2.5",
         "grpc/grpc": "^1.42.",
-        "open-telemetry/api": "^0.0.15",
-        "open-telemetry/opentelemetry-php-contrib": "^0.0.15",
-        "open-telemetry/sdk": "^0.0.15",
-        "open-telemetry/sdk-contrib": "^0.0.15",
+        "open-telemetry/api": "^1.0.0beta3",
+        "open-telemetry/sdk": "^1.0.0beta3",
+        "open-telemetry/contrib-aws": "^1.0.0beta3",
+        "open-telemetry/exporter-otlp" : "^1.0.0beta3",
+        "open-telemetry/transport-grpc" : "^1.0.0beta3",
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/message": "^1.13",
         "sensio/framework-extra-bundle": "^6.2",
@@ -28,7 +29,8 @@
         "allow-plugins": {
             "composer/package-versions-deprecated": true,
             "symfony/flex": true,
-            "symfony/runtime": true
+            "symfony/runtime": true,
+            "php-http/discovery": true
         },
         "optimize-autoloader": true,
         "preferred-install": {

--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
     "require": {
         "aws/aws-sdk-php": "^3.234",
-        "open-telemetry/api": "^0.0.14",
+        "open-telemetry/api": "^1.0.0beta3",
         "php-http/guzzle7-adapter": "^1.0",
-        "open-telemetry/sdk": "^0.0.14",
-        "open-telemetry/sdk-contrib": "^0.0.14",
+        "open-telemetry/sdk": "^1.0.0beta3",
+        "open-telemetry/contrib-aws": "^1.0.0beta3",
         "php-http/message": "^1.13",
         "grpc/grpc": "^1.42"
     }


### PR DESCRIPTION
*Issue #, if available:* #4 

*Description of changes:* This PR updates the sample app to reflect the changes that have been released in the upstream 1.0.0beta: 
- The [open-telemetry/sdk-contrib](https://packagist.org/packages/open-telemetry/sdk-contrib) package has been abandoned in favor of the new packages for each contrib project, in this case [open-telemetry/contrib-aws](https://packagist.org/packages/open-telemetry/contrib-aws)
    - The AwsSdkIntrumentation namespace was also [renamed as part of this change](https://github.com/open-telemetry/opentelemetry-php-contrib/pull/82/files#diff-8e9bf24eeb797e06699cef654acb604328ea492e6747ba833a9db940e9930887R5)
- The `open-telemetry/exporter-otlp-grpc` package has been replaced with two packages which are needed to set up the OTLP exporter: [open-telemetry/exporter-otlp](https://packagist.org/packages/open-telemetry/exporter-otlp) and [open-telemetry/transport-grpc](https://packagist.org/packages/open-telemetry/transport-grpc). The sample app was also updated to reflect the new logic to initialize the OTLP exporter, which can also be found in [this example.](https://github.com/open-telemetry/opentelemetry-php/blob/main/examples/traces/exporters/otlp_grpc.php) 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

