### PR TITLE
Add google/protobuf dependency to sample app composer.json

### DIFF
--- a/SampleApp/composer.json
+++ b/SampleApp/composer.json
@@ -8,7 +8,7 @@
         "ext-iconv": "*",
         "aws/aws-sdk-php": "^3.234",
         "aws/aws-sdk-php-symfony": "^2.5",
-        "grpc/grpc": "^1.42.",
+        "grpc/grpc": "^1.42",
         "open-telemetry/api": "^1.0.0beta3",
         "open-telemetry/sdk": "^1.0.0beta3",
         "open-telemetry/contrib-aws": "^1.0.0beta3",
@@ -23,7 +23,8 @@
         "symfony/framework-bundle": "6.1.*",
         "symfony/http-client": "6.1.*",
         "symfony/runtime": "6.1.*",
-        "symfony/yaml": "6.1.*"
+        "symfony/yaml": "6.1.*",
+        "google/protobuf": ">=3.5.0"
     },
     "config": {
         "allow-plugins": {

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,5 @@
 {
+    "minimum-stability": "dev",
     "require": {
         "aws/aws-sdk-php": "^3.234",
         "open-telemetry/api": "^1.0.0beta3",
@@ -6,6 +7,12 @@
         "open-telemetry/sdk": "^1.0.0beta3",
         "open-telemetry/contrib-aws": "^1.0.0beta3",
         "php-http/message": "^1.13",
-        "grpc/grpc": "^1.42"
+        "grpc/grpc": "^1.42",
+        "ext-grpc": "*"
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": true
+        }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Integration test workflow showed a runtime exception for google/protobuf package 
```
No protobuf implementation found [ext-protobuf or google/protobuf] (500 Internal Server Error)
```
This is related to a [recent change in the opentelemetry-php upstream](https://github.com/open-telemetry/opentelemetry-php/pull/958) that throws a runtime exception in the absence of the protobuf package in composer.json.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

