### PR TITLE
Fix scope detach warning in integration test workflow

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -1,5 +1,7 @@
 name: Integration Testing
 on:
+  pull_request:
+    branches: [main]
   push:
     branches:
       - main


### PR DESCRIPTION
*Issue #, if available:* #8

*Description of changes:* Move `$scope->end` and `$scope->detach` calls to a `finally` block to avoid warnings in integration test workflow

_Note: Temporarily running integration test workflow on PR to ensure run is successful before merging_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

