### PR TITLE
Fix scope detach warning in integration test workflow

### DIFF
--- a/.github/collector/docker-compose.yml
+++ b/.github/collector/docker-compose.yml
@@ -25,7 +25,9 @@ services:
       - LISTEN_ADDRESS=0.0.0.0:8000
       - OTEL_EXPORTER_OTLP_INSECURE=True
       - OTEL_RESOURCE_ATTRIBUTES=service.name=aws-otel-integ-test
-      - OTEL_EXPORTER_OTLP_ENDPOINT=otel:4317
+      - OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=otel:4317
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+      - OTEL_PHP_TRACES_PROCESSOR=simple
     ports:
       - '8000:8000'
 

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -1,7 +1,5 @@
 name: Integration Testing
 on:
-  pull_request:
-    branches: [main]
   push:
     branches:
       - main

--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -1,5 +1,7 @@
 name: Integration Testing
 on:
+  pull_request:
+    branches: [main]
   push:
     branches:
       - main

--- a/SampleApp/composer.json
+++ b/SampleApp/composer.json
@@ -8,14 +8,17 @@
         "ext-iconv": "*",
         "aws/aws-sdk-php": "^3.234",
         "aws/aws-sdk-php-symfony": "^2.5",
+        "google/protobuf": ">=3.5.0",
         "grpc/grpc": "^1.42",
+        "monolog/monolog": "^2.3",
         "open-telemetry/api": "^1.0.0beta3",
-        "open-telemetry/sdk": "^1.0.0beta3",
         "open-telemetry/contrib-aws": "^1.0.0beta3",
-        "open-telemetry/exporter-otlp" : "^1.0.0beta3",
-        "open-telemetry/transport-grpc" : "^1.0.0beta3",
+        "open-telemetry/exporter-otlp": "^1.0.0beta3",
+        "open-telemetry/sdk": "^1.0.0beta3",
+        "open-telemetry/transport-grpc": "^1.0.0beta3",
         "php-http/guzzle7-adapter": "^1.0",
         "php-http/message": "^1.13",
+        "php-http/message-factory": "^1.1",
         "sensio/framework-extra-bundle": "^6.2",
         "symfony/console": "6.1.*",
         "symfony/dotenv": "6.1.*",
@@ -24,7 +27,7 @@
         "symfony/http-client": "6.1.*",
         "symfony/runtime": "6.1.*",
         "symfony/yaml": "6.1.*",
-        "google/protobuf": ">=3.5.0"
+        "ext-grpc": "*"
     },
     "config": {
         "allow-plugins": {


### PR DESCRIPTION
*Issue #, if available:* #8

*Description of changes:* Move `$scope->end` and `$scope->detach` calls to a `finally` block to avoid warnings in the integration test workflow

_Note: Temporarily running integration test workflow on PR to ensure run is successful before merging_


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

