### PR TITLE
Update Sample app and fix Integration Test workflow

### DIFF
--- a/SampleApp/config/services.yaml
+++ b/SampleApp/config/services.yaml
@@ -20,5 +20,9 @@ services:
             - '../src/Entity/'
             - '../src/Kernel.php'
 
+    App\Controller\:
+        resource: '../src/Controller'
+        tags: ['controller.service_arguments']
+
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/SampleApp/src/Controller/AwsSdkInstrumentationController.php
+++ b/SampleApp/src/Controller/AwsSdkInstrumentationController.php
@@ -5,7 +5,8 @@ use Aws\Exception\AwsException;
 use Aws\S3\S3Client;
 
 use OpenTelemetry\API\Trace\SpanKind;
-use OpenTelemetry\API\Common\Signal\Signals;
+use OpenTelemetry\API\Signals;
+use OpenTelemetry\API\LoggerHolder;
 
 use OpenTelemetry\Contrib\Otlp\OtlpUtil;
 use OpenTelemetry\Contrib\Otlp\SpanExporter;
@@ -24,7 +25,12 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Annotation\Route;
 
-\OpenTelemetry\API\Common\Log\LoggerHolder::set(new \Monolog\Logger('grpc', [new \Monolog\Handler\StreamHandler('php://stderr')]));
+use Monolog\Handler\StreamHandler;
+use Monolog\Logger;
+
+LoggerHolder::set(
+    new Logger('grpc', [new StreamHandler('php://stderr')])
+);
 
 class AwsSdkInstrumentationController
 {


### PR DESCRIPTION
*Issue #, if available:*
Failed workflow: https://github.com/aws-observability/aws-otel-php/actions/runs/7454073172

2 updates caused Sample App and Integration workflow to stop working:
- OTel PHP directory restructured
  - e.g. `OpenTelemetry\API\Common\Signal\Signals;` -> `OpenTelemetry\API\Signals;`
- updated version of the Symfony package. Routes are marked as private if they are not explicitly marked as public in the `config/services.yaml`) file.

*Description of changes:*

1. Updated directories to address bullet point (1)
2. To address bullet point (2), followed guidance in [symfony documentation](https://symfony.com/doc/current/controller/service.html), tag app controller with `controller.service_arguments`

Testing:
Local workflow success: https://github.com/jj22ee/aws-otel-php/actions/runs/7466757434/job/20318831739

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

