### PR TITLE
Pin GitHub Action references to commit SHAs

### DIFF
--- a/.github/workflows/integration-testing.yml
+++ b/.github/workflows/integration-testing.yml
@@ -16,26 +16,26 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository 
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 #v3.6.0
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 #v1.7.0
 
       - name: Cache Docker layer 
-        uses: actions/cache@v3
+        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3.5.0
         with:
             path: /tmp/.buildx-cache
             key: ${{ runner.os }}-buildx-${{ github.sha }}
       
       - name: Configure AWS Credentials 
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 #v1.7.0
         with:
           role-to-assume: ${{ secrets.AWS_ASSUME_ROLE_ARN }}
           role-duration-seconds: 2400 
           aws-region: us-east-1
       
       - name: Login to ECR
-        uses: docker/login-action@v2
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc #v2.2.0
         with:
           registry: public.ecr.aws 
       
@@ -43,7 +43,7 @@ jobs:
         id: composer-cache
         run: |
           echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
-      - uses: actions/cache@v3
+      - uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c #v3.5.0
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,33 @@
+name: PR Build
+on:
+  pull_request:
+  
+permissions:
+  contents: read
+
+# TODO: Add build/test steps
+jobs:
+  static-code-checks:
+    runs-on: ubuntu-latest
+    steps:
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 #5.0.0
+        with:
+          fetch-depth: 0
+      - name: Check for versioned GitHub actions
+        if: always()
+        run: |
+          # Get changed GitHub workflow/action files
+          CHANGED_FILES=$(git diff --name-only origin/${{ github.base_ref }}..HEAD | grep -E "^\.github/(workflows|actions)/.*\.ya?ml$" || true)
+          
+          if [ -n "$CHANGED_FILES" ]; then
+            # Check for any versioned actions, excluding comments and this validation script
+            VIOLATIONS=$(grep -Hn "uses:.*@v" $CHANGED_FILES | grep -v "grep.*uses:.*@v" | grep -v "#.*@v" || true)
+            if [ -n "$VIOLATIONS" ]; then
+              echo "Found versioned GitHub actions. Use commit SHAs instead:"
+              echo "$VIOLATIONS"
+              exit 1
+            fi
+          fi
+          
+          echo "No versioned actions found in changed files"


### PR DESCRIPTION
## Summary

Pin all GitHub Action references to full commit SHAs instead of mutable version tags to prevent supply chain attacks. This is a security best practice recommended by [GitHub's security hardening guide](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).

Mutable version tags (e.g. `@v2`) can be moved to point to different commits, meaning a compromised upstream action could execute malicious code in our workflows. Pinning to commit SHAs ensures we always run the exact code we've reviewed.

## Changes

| Old Reference | New Reference | Hash | Version |
|--------------|---------------|------|---------|
| actions/cache@v3 | actions/cache@6f8efc29b200d32929f49075959781ed54ec270c | 6f8efc29b200d32929f49075959781ed54ec270c | [v3.5.0](https://github.com/actions/cache/releases/tag/v3.5.0) |
| actions/checkout@v3 | actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 | f43a0e5ff2bd294095638e18286ca9a3d1956744 | [v3.6.0](https://github.com/actions/checkout/releases/tag/v3.6.0) |
| aws-actions/configure-aws-credentials@v1 | aws-actions/configure-aws-credentials@67fbcbb121271f7775d2e7715933280b06314838 | 67fbcbb121271f7775d2e7715933280b06314838 | [v1.7.0](https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.7.0) |
| docker/login-action@v2 | docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc | 465a07811f14bebb1938fbed4728c6a1ff8901fc | [v2.2.0](https://github.com/docker/login-action/releases/tag/v2.2.0) |
| docker/setup-buildx-action@v1 | docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 | f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 | [v1.7.0](https://github.com/docker/setup-buildx-action/releases/tag/v1.7.0) |

## Static Code Check

Added a `static-code-checks` job to `pr-build.yml` that will fail PRs introducing mutable GitHub Action version references.
